### PR TITLE
Handle returned values that evaluate to false

### DIFF
--- a/lib/hiera/backend/consul_backend.rb
+++ b/lib/hiera/backend/consul_backend.rb
@@ -98,7 +98,7 @@ class Hiera
                   answer = this_answer.merge(answer) unless ! this_answer #Earliest value takes precedence
                 else #if resolution_type == :priority
                   answer = this_answer 
-                  throw :found if answer
+                  throw :found if ! answer.nil?
                 end
               end
 
@@ -127,7 +127,7 @@ class Hiera
                     answer = this_answer.merge(answer) unless ! this_answer #Earliest value takes precedence
                   else #if resolution_type == :priority
                     answer = this_answer 
-                    throw :found if answer
+                    throw :found if ! answer.nil?
                   end
                 end
               end
@@ -149,7 +149,7 @@ class Hiera
                   answer = this_answer.merge(answer) unless ! this_answer #Earliest value takes precedence
                 else #if resolution_type == :priority
                   answer = this_answer 
-                  throw :found if answer
+                  throw :found if ! answer.nil?
                 end
               end
 


### PR DESCRIPTION
Have been experimenting with this for the past few days and noticed that a value of "false" from consul gets evaluated to an actual boolean false and causes the lookup to continue to the next path when false is the value i wanted returned.
